### PR TITLE
Delete Subscription

### DIFF
--- a/internal/database/database.go
+++ b/internal/database/database.go
@@ -100,6 +100,46 @@ func (d *Database) GetSubscriptions() ([]subscription.Subscription, error) {
 	return subscriptions, nil
 }
 
+// GetSubscription retrieves a single subscription that has the given ID from the subscription database
+// If no subscription is found with the given ID, it returns a nil pointer
+func (d *Database) GetSubscription(subscriptionID int) (*subscription.Subscription, error) {
+
+	var id int
+	var name string
+	var amount pgtype.Numeric
+	var dateDue time.Time
+
+	selectQuery := `
+	SELECT id, name, amount, date_due FROM subscriptions
+	WHERE id=$1`
+
+	err := d.database.QueryRowContext(
+		context.Background(),
+		selectQuery,
+		subscriptionID,
+	).Scan(
+		&id,
+		&name,
+		&amount,
+		&dateDue,
+	)
+
+	switch {
+	case err == sql.ErrNoRows:
+		return nil, nil
+	case err != nil:
+		return nil, fmt.Errorf("unexpected database error: %w", err)
+	default:
+		retrievedSubscription := subscription.Subscription{
+			ID:      id,
+			Name:    name,
+			Amount:  decimal.NewFromBigInt(amount.Int, amount.Exp),
+			DateDue: dateDue,
+		}
+		return &retrievedSubscription, nil
+	}
+}
+
 // DeleteSubscription deletes a subscription from the database by ID
 func (d *Database) DeleteSubscription(subscriptionID int) error {
 	result, err := d.database.ExecContext(context.Background(), "DELETE FROM subscriptions WHERE id = $1;", subscriptionID)

--- a/internal/database/database_test.go
+++ b/internal/database/database_test.go
@@ -99,6 +99,54 @@ func TestGetSubscriptionsFromDB(t *testing.T) {
 
 }
 
+func TestGetSubscriptionByIDFromDB(t *testing.T) {
+	store, err := NewDatabaseConnection(os.Getenv("DATABASE_CONN_STRING"))
+	assertDatabaseError(t, err)
+
+	t.Run("returns the subscription with given ID from DB", func(t *testing.T) {
+		subscription := createTestSubscription()
+
+		wantedSubscription, err := store.RecordSubscription(subscription)
+		assertDatabaseError(t, err)
+
+		gotSubscription, err := store.GetSubscription(wantedSubscription.ID)
+		assertDatabaseError(t, err)
+
+		if gotSubscription.ID != wantedSubscription.ID {
+			t.Errorf("Database did not return an ID, got %v want %v", 0, subscription.ID)
+		}
+
+		if gotSubscription.Name != wantedSubscription.Name {
+			t.Errorf("Database did not return correct subscription name, got %s want %s", subscription.Name, subscription.Name)
+		}
+
+		if !gotSubscription.Amount.Equal(wantedSubscription.Amount) {
+			t.Errorf("Database did not return correct amount, got %#v want %#v", subscription.Amount, subscription.Amount)
+		}
+
+		if !gotSubscription.DateDue.Equal(wantedSubscription.DateDue) {
+			t.Errorf("Database did not return correct subscription date, got %s want %s", subscription.DateDue, subscription.DateDue)
+		}
+
+		err = clearSubscriptionsTable()
+		assertDatabaseError(t, err)
+	})
+
+	t.Run("returns nil if a subscription with the given ID does not exist in the DB", func(t *testing.T) {
+
+		gotSubscription, err := store.GetSubscription(2)
+		assertDatabaseError(t, err)
+
+		if gotSubscription != nil {
+			t.Errorf("Database returned value for non-existent subscription, got %v want %v", gotSubscription, nil)
+		}
+
+		err = clearSubscriptionsTable()
+		assertDatabaseError(t, err)
+	})
+
+}
+
 func TestDeletingSubscriptionFromDB(t *testing.T) {
 	store, err := NewDatabaseConnection(os.Getenv("DATABASE_CONN_STRING"))
 	assertDatabaseError(t, err)

--- a/internal/database/in_memory_subscriptions_store.go
+++ b/internal/database/in_memory_subscriptions_store.go
@@ -23,12 +23,11 @@ func (i *InMemorySubscriptionStore) GetSubscriptions() ([]subscription.Subscript
 // GetSubscription retrieves a single subscription that has the given ID from the InMemoryDataStore
 // If no subscription is found with the given ID, it returns a nil pointer
 func (i *InMemorySubscriptionStore) GetSubscription(ID int) (*subscription.Subscription, error) {
-	for _, value := range i.subscriptions {
-		if value.ID == ID {
-			return &value, nil
-		}
+	index := i.findSubscriptionIndex(ID)
+	if index == -1 {
+		return nil, nil
 	}
-	return nil, nil
+	return &i.subscriptions[index], nil
 }
 
 // RecordSubscription is a method that stores a subscription into the store

--- a/internal/database/in_memory_subscriptions_store.go
+++ b/internal/database/in_memory_subscriptions_store.go
@@ -40,11 +40,13 @@ func (i *InMemorySubscriptionStore) RecordSubscription(subscription subscription
 func (i *InMemorySubscriptionStore) DeleteSubscription(subscriptionID int) error {
 
 	index := i.findSubscriptionIndex(subscriptionID)
+	lastIndex := len(i.subscriptions)-1
+
 	if index == -1 {
 		return fmt.Errorf("failed to delete subscription with ID %v", subscriptionID)
 	}
-	i.subscriptions[len(i.subscriptions)-1], i.subscriptions[index] = i.subscriptions[index], i.subscriptions[len(i.subscriptions)-1]
-	i.subscriptions = i.subscriptions[:len(i.subscriptions)-1]
+	i.subscriptions[lastIndex], i.subscriptions[index] = i.subscriptions[index], i.subscriptions[lastIndex]
+	i.subscriptions = i.subscriptions[:lastIndex]
 	return nil
 }
 

--- a/internal/database/in_memory_subscriptions_store.go
+++ b/internal/database/in_memory_subscriptions_store.go
@@ -1,6 +1,9 @@
 package database
 
-import "github.com/Catzkorn/subscrypt/internal/subscription"
+import (
+	"fmt"
+	"github.com/Catzkorn/subscrypt/internal/subscription"
+)
 
 // NewInMemorySubscriptionStore returns a instance of InMemorySubscriptionStore
 func NewInMemorySubscriptionStore() *InMemorySubscriptionStore {
@@ -17,9 +20,42 @@ func (i *InMemorySubscriptionStore) GetSubscriptions() ([]subscription.Subscript
 	return i.subscriptions, nil
 }
 
-// RecordSubscription is a method that stores a subscription into the store
+// GetSubscription retrieves a single subscription that has the given ID from the InMemoryDataStore
+// If no subscription is found with the given ID, it returns a nil pointer
+func (i *InMemorySubscriptionStore) GetSubscription(ID int) (*subscription.Subscription, error) {
+	for _, value := range i.subscriptions {
+		if value.ID == ID {
+			return &value, nil
+		}
+	}
+	return nil, nil
+}
 
+// RecordSubscription is a method that stores a subscription into the store
 func (i *InMemorySubscriptionStore) RecordSubscription(subscription subscription.Subscription) (*subscription.Subscription, error) {
 	i.subscriptions = append(i.subscriptions, subscription)
 	return &subscription, nil
+}
+
+// DeleteSubscription deletes a subscription from the data store with the given ID
+func (i *InMemorySubscriptionStore) DeleteSubscription(subscriptionID int) error {
+
+	index := i.findSubscriptionIndex(subscriptionID)
+	if index == -1 {
+		return fmt.Errorf("failed to delete subscription with ID %v", subscriptionID)
+	}
+	i.subscriptions[len(i.subscriptions)-1], i.subscriptions[index] = i.subscriptions[index], i.subscriptions[len(i.subscriptions)-1]
+	i.subscriptions = i.subscriptions[:len(i.subscriptions)-1]
+	return nil
+}
+
+// FindSubscriptionIndex finds the index of a given subscription ID, from the InMemoryDataStore's subscriptions
+// If no corresponding subscription is found then it returns -1
+func (i *InMemorySubscriptionStore) findSubscriptionIndex(ID int) (index int) {
+	for index, value := range i.subscriptions {
+		if value.ID == ID {
+			return index
+		}
+	}
+	return -1
 }

--- a/internal/integration_test/integration_test.go
+++ b/internal/integration_test/integration_test.go
@@ -113,6 +113,8 @@ func TestDeletingSubscriptionFromDatabase(t *testing.T) {
 	bodyString := string(body)
 	got := bodyString
 
+	assertStatus(t, response.Code, http.StatusFound)
+
 	res := !strings.Contains(got, storedSubscription.Name)
 
 	if res != true {
@@ -141,6 +143,13 @@ func assertDatabaseError(t *testing.T, err error) {
 	t.Helper()
 	if err != nil {
 		t.Fatalf("unexpected database error: %v", err)
+	}
+}
+
+func assertStatus(t *testing.T, got, want int) {
+	t.Helper()
+	if got != want {
+		t.Errorf("did not get correct status, got %d, want %d", got, want)
 	}
 }
 

--- a/internal/server/index.go
+++ b/internal/server/index.go
@@ -23,10 +23,7 @@ const indexTemplate = `<!DOCTYPE html>
             <td>{{.Name}}</td>
             <td>{{.Amount}}</td>
             <td>{{.DateDue}}</td>
-			<td><form action="/delete"  method="post">
-			<input type ="hidden" name="ID" value={{.ID}}>
-			<input type="submit" value="Delete">
-			</form>
+			<td><button type="button" id="delete-{{.ID}}" onclick="deleteSubscription({{.ID}})">Delete</button>
         </tr>
     {{end}}
 </table>
@@ -40,6 +37,20 @@ const indexTemplate = `<!DOCTYPE html>
     <input type="date" name="date"><br>
     <input type="submit" value="Submit">
 </form>
+
+<script>
+	function deleteSubscription(id) {
+		let xhttp = new XMLHttpRequest();
+		let url = "/api/subscriptions/" + id
+		xhttp.onreadystatechange = function () {
+			if (xhttp.readyState === 4 && xhttp.status === 200) {
+				window.location.href = "/";
+			}
+		}
+		xhttp.open("DELETE", url, true);
+		xhttp.send();
+	}
+</script>
 
 </body>
 </html>`

--- a/internal/server/index.go
+++ b/internal/server/index.go
@@ -23,6 +23,10 @@ const indexTemplate = `<!DOCTYPE html>
             <td>{{.Name}}</td>
             <td>{{.Amount}}</td>
             <td>{{.DateDue}}</td>
+			<td><form action="/delete"  method="post">
+			<input type ="hidden" name="ID" value={{.ID}}>
+			<input type="submit" value="Delete">
+			</form>
         </tr>
     {{end}}
 </table>
@@ -36,7 +40,6 @@ const indexTemplate = `<!DOCTYPE html>
     <input type="date" name="date"><br>
     <input type="submit" value="Submit">
 </form>
-
 
 </body>
 </html>`

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -95,14 +95,14 @@ func TestStoreSubscription(t *testing.T) {
 	})
 }
 
-func TestDeleteSubscription(t *testing.T) {
+func TestDeleteSubscriptionAPI(t *testing.T) {
 
-	t.Run("deletes the specified subscription from the data store", func(t *testing.T) {
+	t.Run("deletes the specified subscription from the data store and returns 200", func(t *testing.T) {
 		subscriptions := []subscription.Subscription{{ID: 1}}
 		store := &StubDataStore{subscriptions: subscriptions}
 		server := NewServer(store)
 
-		request := newPostDeleteRequest(url.Values{"ID": {"1"}})
+		request := newDeleteSubscriptionRequest(1)
 
 		response := httptest.NewRecorder()
 
@@ -118,7 +118,7 @@ func TestDeleteSubscription(t *testing.T) {
 		store := &StubDataStore{subscriptions: subscriptions}
 		server := NewServer(store)
 
-		request := newPostDeleteRequest(url.Values{"ID": {"2"}})
+		request := newDeleteSubscriptionRequest(2)
 
 		response := httptest.NewRecorder()
 
@@ -143,13 +143,13 @@ func newPostFormRequest(url url.Values) *http.Request {
 	return req
 }
 
-func newPostDeleteRequest(url url.Values) *http.Request {
-	var bodyStr = []byte(url.Encode())
-	req, err := http.NewRequest(http.MethodPost, "/delete", bytes.NewBuffer(bodyStr))
+func newDeleteSubscriptionRequest(ID int) *http.Request {
+	bodyStr := []byte(fmt.Sprintf("{\"id\": %v}", ID))
+	url := fmt.Sprintf("/api/subscriptions/%v", ID)
+	req, err := http.NewRequest(http.MethodDelete, url, bytes.NewBuffer(bodyStr))
 	if err != nil {
 		panic(err)
 	}
-	req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
 	return req
 }
 


### PR DESCRIPTION
Implements ability to delete a subscription:

- Users can click a 'Delete' on each of the existing subscriptions, which makes a request to '/api/subscriptions/:id'
- Delete subscription API takes in a subscription ID and validates that the subscription exists, returning 404 if not found.
- If found, it deletes the subscription from the data store.