### PR TITLE
Fix index.html path lookup

### DIFF
--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -4,6 +4,9 @@ import (
 	"fmt"
 	"html/template"
 	"net/http"
+	"path"
+	"path/filepath"
+	"runtime"
 	"strconv"
 	"strings"
 	"time"
@@ -134,7 +137,11 @@ func (s *Server) processGetSubscription(w http.ResponseWriter) error {
 		Userprofile:   userInfo,
 	}
 
-	err = s.parsedIndexTemplate.Execute(w, data)
+	_, file, _, _ := runtime.Caller(0)
+	path := filepath.Join(path.Dir(file), "../../web/index.html")
+	parsedIndexTemplate := template.Must(template.New("index.html").ParseFiles(path))
+
+	err = parsedIndexTemplate.Execute(w, data)
 
 	if err != nil {
 		return err


### PR DESCRIPTION
- Ensure that index.html is looked up at the correct location from both tests and terminal sessions by using the absolute path to the source file and navigating to the parent directory